### PR TITLE
Creates a category for PFTA—Telium

### DIFF
--- a/_posts/2020-05-05-PFTA—Telium_v1.76.0-v.17.0.md
+++ b/_posts/2020-05-05-PFTA—Telium_v1.76.0-v.17.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: PFTA—Telium v1.76.0 / v1.77.0
-tag: PFTA
+tag: PFTA-Telium
 author: AxiaMed
 ---
 We've updated the Payment Fusion Terminal Application for Telium devices to support online remote key injection (ORKI), and improve performance.


### PR DESCRIPTION
Brock wanted to separate PFTA—Telium and PFTA—Android on the release notes page. He's categorized Android releases. This is following suit for Telium.